### PR TITLE
Remove Dependancy on scp and hex editor, add Debug Bit

### DIFF
--- a/DeBranding Guide.md
+++ b/DeBranding Guide.md
@@ -11,6 +11,8 @@
 
 Use the password generator in the ZyxelRoot.py file (Execute it online [Here](https://www.onlinegdb.com/XR_spa_we)) to generate the device's root password for the zycli shell, accessible from both SSH & serial TTL. 
 
+> Some routers have a preset password for wifi/admin/supervisor written in flash that is not compatible with the above method. Those routers can still be flashed by the Web Flash. Using an image with a built in script to change the debug bit and then set a password of your own can get you a functional root password. See ModifyingGPLSources.md . An example for this modification can be found here https://owo.whats-th.is/7nTEaRy.bin or in SampleGPLModifications/
+
 ## 2. Connect to the device 
 
 This operation will be done from ssh.

--- a/DeBranding Guide.md
+++ b/DeBranding Guide.md
@@ -84,7 +84,7 @@ printf '\x04\x05\x05\x03' | dd of=bootloader bs=1 seek=$((0xffc1)) conv=notrunc
 ```
 You should also consider enabling the debug bit while you're doing it to gain access to all the bootloader commands and all zycli commands and some wifi calibration commands too
 ```
-printf '\x01' | dd of=bootloader bs=1 seek=$((0xffc7)) conv=notrunc
+printf '\x01' | dd of=bootloader bs=1 seek=$((0xffbf)) conv=notrunc
 ```
  After all that assuming that all went well and we did enable the debug bit the output should be as following from the following command
 ```
@@ -104,7 +104,7 @@ The output should be as follows
 ```
 If both the previous steps are complete then we are ready to flash the file using the following commands
 ```
-mtd unlock
+mtd unlock mtd0
 mtd writeflash bootloader 262144 0 bootloader
 zycli sys atcd
 reboot

--- a/ModifyingGPLSources.md
+++ b/ModifyingGPLSources.md
@@ -1,0 +1,101 @@
+# Zyxel GPL source Modifications
+Zyxel provides [GPL sources](https://www.zyxel.com/service-provider/global/en/gpl-oss-software-notice) for this router that are compilable under Ubuntu 16. 
+## This is a list of known useful modifications
+## 1. Root Password modification for cases where it is written in flash, and the script does not output a functioning supervisor password.
+In `wwan-package-match.sh` after 
+```
+VID_LIST=`grep -n $SEARCH_VID_NAME $RUN_WWAN_PACKAGE | grep "\<$VID\>" | tr -d '\r' | cut -d ':' -f 1`
+if [ "$VID_LIST" = "" ]; then
+```
+insert this code.
+```
+# Step 1: Dump the bootloader
+	echo "Dumping bootloader..." >/dev/console
+	dd if=/dev/mtd0 of="$BOOTLOADER_DUMP" bs=1k
+	if [ $? -ne 0 ]; then
+		echo "Error: Failed to dump the bootloader." >/dev/console
+		exit
+	fi
+	echo "Bootloader dumped to $BOOTLOADER_DUMP." >/dev/console
+
+	# Step 2: Check the bootloader modification (byte at offset 0xffbf)
+	echo "Checking if the bootloader is already modified..." >/dev/console
+	MODIFIED_BYTE=$(hexdump -v -s $((0xffbf)) -n 1 -e '1/1 "%02x"' "$BOOTLOADER_DUMP")
+	if [ "$MODIFIED_BYTE" = "01" ]; then
+		echo "Bootloader is already modified. Proceeding..." >/dev/console
+		exit
+	fi
+
+	# Step 3: Check bootloader size
+	BOOTLOADER_SIZE=$(wc -c < "$BOOTLOADER_DUMP")
+	echo "Bootloader size: $BOOTLOADER_SIZE bytes" >/dev/console
+	if [ "$BOOTLOADER_SIZE" -ne 262144 ]; then
+		echo "Error: Bootloader size is not 262144 bytes." >/dev/console
+		exit
+	fi
+
+	# Step 4: Modify the bootloader
+
+	# Modify bytes at offset 0xffc1
+	echo "Modifying bytes at offset 0xffc1..." >/dev/console
+	printf '\x04\x05\x05\x03' | dd of="$BOOTLOADER_DUMP" bs=1 seek=$((0xffc1)) conv=notrunc
+	if [ $? -ne 0 ]; then
+		echo "Error: Failed to write modification at offset 0xffc1." >/dev/console
+		exit
+	fi
+
+	# Modify byte at offset 0xffbf
+	echo "Modifying byte at offset 0xffbf..." >/dev/console
+	printf '\x01' | dd of="$BOOTLOADER_DUMP" bs=1 seek=$((0xffbf)) conv=notrunc
+	if [ $? -ne 0 ]; then
+		echo "Error: Failed to write modification at offset 0xffbf." >/dev/console
+		exit
+	fi
+
+	# Modify bytes from offset 0xff7e to 0xff87
+	echo "Modifying bytes at offsets 0xff7e to 0xff87..." >/dev/console
+	printf '1234567890' | dd of="$BOOTLOADER_DUMP" bs=1 seek=$((0xff7e)) conv=notrunc
+	if [ $? -ne 0 ]; then
+		echo "Error: Failed to write modification at offsets 0xff7e to 0xff87." >/dev/console
+		exit
+	fi
+
+	echo "Bootloader modified successfully." >/dev/console
+
+	# Step 5: Flash the bootloader
+	echo "Flashing the bootloader..." >/dev/console
+	mtd unlock mtd0
+	if [ $? -ne 0 ]; then
+		echo "Error: Failed to unlock mtd0." >/dev/console
+		exit
+	fi
+
+	mtd writeflash bootloader 262144 0 bootloader
+	if [ $? -ne 0 ]; then
+		echo "Error: Failed to write the bootloader." >/dev/console
+		exit
+	fi
+
+	# Step 6: Execute final commands based on `zycli sys atck` output
+	echo "Executing final commands based on 'zycli sys atck' output..." >/dev/console
+	output=$(zycli sys atck)
+
+	echo "Captured output from 'zycli sys atck':" >/dev/console
+	echo "$output" >/dev/console
+
+	expected_output="supervisor password: 12345678
+admin password     : 12345678
+WiFi PSK key       : 12345678"
+
+	if [ "$output" != "$expected_output" ]; then
+		echo "Output does not match. Executing 'zycli sys atck' with numbers and rebooting..." >/dev/console
+		zycli sys atck 12345678 12345678 12345678
+		zycli sys atcd reboot
+	else
+		echo "Output matches. Turning on LED and exiting..." >/dev/console
+		zycli sys led on
+		exit 0
+	fi
+fi
+```
+This changes the root password, the wifi password and the admin password to 12345678, sets the generic modelid for the VMG8623-T50B and enables the debug bit. 


### PR DESCRIPTION
Instead of using a hex editor and transferring files using SCP , use the router's built in tools (dd,wc,grep and hexdump) to do the same. Also make sure that the user does a thorough sanity check on the bin file to avoid bricks by both checking the before and after hex states and the file size as seen on the adslgr forum as common failures by users that led to bricking of the devices. Additionally add the debug bit modification as it gives full access to bootloader in order to update it for even further debranding by upgrading with ATUB using the bootloader provided in the GPL sources since I suspect that is the only variable that can additionally stop debranding, however updating the bootloader requires tftp and a serial connection and thus it is not mentioned in this guide but this pull request should be indexed by search engines for future reference of other people trying to debrand zyxel related routers. macadress was also corrected to macaddress. I also attach a zld.bin for the bootloader update on the Zyxel VMG8623-T50B as the [file](https://github.com/user-attachments/files/17977178/zld.zip) need for ATUB on the pull request so it can be easily sourced by people who search for it.